### PR TITLE
Bump php version 7.0 to 7.1

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,7 +15,7 @@ brew 'bash-completion'
 # languages
 brew 'node'
 brew 'go'
-brew 'php70'
+brew 'php71'
 brew 'php56'
 brew 'python3'
 


### PR DESCRIPTION
When onboarding the `./setup` script failed when trying to install *php70*
Updating to 7.1