### PR TITLE
Remove tap caskroom since it is included with homebrew now

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 cask_args appdir: '/Applications'
 
 # taps
+tap 'caskroom/homebrew-cask' || true
 tap 'homebrew/core' || true
 
 # version control
@@ -61,6 +62,7 @@ cask 'skitch'
 cask 'ngrok'
 cask 'docker'
 brew 'kubernetes-cli'
+brew 'cloudflared'
 
 # fun
 cask 'spotify'

--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,6 @@
 cask_args appdir: '/Applications'
 
 # taps
-tap 'caskroom/homebrew-cask' || true
 tap 'homebrew/core' || true
 
 # version control


### PR DESCRIPTION
Not sure when this was added in, but it is no longer necessary to tap caskroom since it is included in homebrew.  
reference:
* https://stackoverflow.com/a/58337898