### PR TITLE
WIP: Remove Sequel Pro for Sequel Ace

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -29,7 +29,7 @@ brew 'yarn'
 # databases
 brew 'mysql'
 brew 'redis'
-cask 'sequel-pro'
+cask 'sequel-ace'
 
 # messaging
 brew 'rabbitmq'


### PR DESCRIPTION
Sequel Pro is deprecated and has been picked up under Sequel Ace

https://github.com/Sequel-Ace/Sequel-Ace