### PR TITLE
Remove Sequel Pro for Sequel Ace

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -29,7 +29,7 @@ brew 'yarn'
 # databases
 brew 'mysql'
 brew 'redis'
-cask 'sequel-pro'
+cask 'sequel-ace'
 
 # messaging
 brew 'rabbitmq'

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The binaries and instructions to install them can be found here https://php-osx.
 ### Databases
 - [mysql](https://www.mysql.com)
 - [redis](https://redis.io/)
+- [Sequel Ace](https://github.com/Sequel-Ace/Sequel-Ace)
 
 ## Messaging
 - [rabbitmq](https://www.rabbitmq.com/)


### PR DESCRIPTION
Sequel Pro is deprecated and has been picked up under Sequel Ace

https://github.com/Sequel-Ace/Sequel-Ace