### PR TITLE
Updated Setup File for New Brew Path

### DIFF
--- a/setup
+++ b/setup
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 
-if [ -x /usr/local/bin/brew ];
+if [ -x /opt/homebrew/bin ];
 then
     echo "Skipping install of brew. It is already installed.";
     echo "Updating brew..."
@@ -10,7 +10,7 @@ then
 else
     echo "Installing brew...";
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)";
-    if [ -x /usr/local/bin/brew ];
+    if [ -x /opt/homebrew/bin ];
     then
         echo "Installed brew";
     else


### PR DESCRIPTION
One of our new co-op was having issue with running the install script. After further investigation it looks like fresh brew installs are in the following path `/opt/homebrew/bin`,  thus breaking our setup script.  This MR updates the setup file with the new path.