### PR TITLE
Update homebrew install curl and brew locations

### DIFF
--- a/setup
+++ b/setup
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 
-if [ -x /opt/homebrew/bin ];
+if [ -x /usr/local/bin/brew ] || [ -x /opt/homebrew/bin ];
 then
     echo "Skipping install of brew. It is already installed.";
     echo "Updating brew..."
@@ -9,8 +9,8 @@ then
     echo "Updated brew."
 else
     echo "Installing brew...";
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)";
-    if [ -x /opt/homebrew/bin ];
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)";
+    if [ -x /usr/local/bin/brew ] || [ -x /opt/homebrew/bin ];
     then
         echo "Installed brew";
     else


### PR DESCRIPTION
Updated homebrew install curl address (previous was deprecated and giving a warning)

A previous MR had changed the brew install loc from `/usr/local/bin/brew` to `/opt/homebrew/bin`, however `/usr/local/bin/brew` was the correct loc for my specific installation. Adding a check for either install location to correct either case.